### PR TITLE
Fix future import placement

### DIFF
--- a/tests/test_future_imports.py
+++ b/tests/test_future_imports.py
@@ -1,0 +1,25 @@
+import textwrap
+from pathlib import Path
+from pyonetrue import FlatteningContext
+
+
+def test_future_import_after_docstring(tmp_path):
+    pkg = tmp_path / 'pkg'
+    pkg.mkdir()
+    source = textwrap.dedent('''
+        """module docstring"""
+        from __future__ import print_function
+        import os
+        def foo():
+            pass
+    ''')
+    (pkg / '__init__.py').write_text(source)
+
+    ctx = FlatteningContext(package_path=pkg)
+    ctx.add_module(pkg / '__init__.py')
+    spans = ctx.get_final_output_spans()
+    text = ''.join(span.text for span in spans)
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    assert lines[0] == '"""module docstring"""'
+    assert lines[1] == 'from __future__ import print_function'
+    assert lines[2] == 'import os'


### PR DESCRIPTION
## Summary
- keep package docstring and future imports ordered correctly
- avoid duplicating `__main__` code during flattening
- ensure main spans have no import statements
- add regression test for `__future__` order

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b90633d548326905745eff7f000a3