### PR TITLE
Use vendored pathlib

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -14,7 +14,7 @@ Options:
 import os
 import sys
 import subprocess
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 import shutil
 
 from vendor.docopt import docopt

--- a/src/pyonetrue/cli.py
+++ b/src/pyonetrue/cli.py
@@ -57,7 +57,7 @@ Options:
 """
 
 import sys
-from pathlib import Path
+from .vendor.pathlib import Path
 
 from .vendor.docopt import docopt
 from .flattening import FlatteningContext

--- a/src/pyonetrue/extract_ast.py
+++ b/src/pyonetrue/extract_ast.py
@@ -2,7 +2,7 @@
 
 import ast
 from typing import List, Union
-from pathlib import Path
+from .vendor.pathlib import Path
 
 class Span:
     """Represents a contiguous block of top-level code in the source file.

--- a/src/pyonetrue/flattening.py
+++ b/src/pyonetrue/flattening.py
@@ -1,5 +1,5 @@
 import sys
-from pathlib import Path
+from .vendor.pathlib import Path
 import importlib.util
 from dataclasses import dataclass, field
 from typing import List, Union

--- a/src/pyonetrue/vendor/pathlib.py
+++ b/src/pyonetrue/vendor/pathlib.py
@@ -1,0 +1,13 @@
+"""Vendored pathlib module.
+
+This module simply re-exports everything from the standard library
+``pathlib`` package.  It exists so that the rest of the project can
+consistently import :class:`Path` and related helpers from
+``pyonetrue.vendor.pathlib`` instead of relying directly on the
+interpreter's implementation.
+"""
+
+import pathlib as _stdlib_pathlib
+from pathlib import *  # noqa: F401,F403
+
+__all__ = getattr(_stdlib_pathlib, "__all__", [n for n in globals() if not n.startswith("_")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import sys
 import subprocess
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 import pytest
 
 import io

--- a/tests/test_flattening.py
+++ b/tests/test_flattening.py
@@ -1,5 +1,5 @@
 import pytest
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 
 import textwrap
 

--- a/tests/test_future_imports.py
+++ b/tests/test_future_imports.py
@@ -1,5 +1,5 @@
 import textwrap
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 from pyonetrue import FlatteningContext
 
 

--- a/tests/test_main_py.py
+++ b/tests/test_main_py.py
@@ -3,7 +3,7 @@ import os
 import io
 import contextlib
 import pytest
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 from pyonetrue import main
 from pyonetrue import FlatteningContext
 from pyonetrue import extract_spans, Span

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -3,7 +3,7 @@ import os
 import io
 import contextlib
 import pytest
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 from pyonetrue import main
 from pyonetrue import FlatteningContext
 from pyonetrue import extract_spans, Span

--- a/tests/test_z_round_trip.py
+++ b/tests/test_z_round_trip.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import subprocess
-from pathlib import Path
+from pyonetrue.vendor.pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary
- vendor the stdlib `pathlib` so all code imports `pyonetrue.vendor.pathlib`
- update CLI and core modules to use the vendored `Path`
- update scripts and tests to use the vendored module

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ce3cc739083269c28198bd4030b03