### PR TITLE
Fix docs 0.6 reference

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include LICENSE
-include doc/0.5/USAGE.txt
+include doc/0.6/USAGE.txt
 
 recursive-include src/pyonetrue *.py
 recursive-include tests *.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME           := pyonetrue
 PROJECT        := $${PWD\#\#*/}
-# FILES          := {Makefile,${NAME},doc/0.5,src,tests,scripts}
+# FILES          := {Makefile,${NAME},doc/0.6,src,tests,scripts}
 FILES          := {Makefile,LICENSE,*.*,src,tests,scripts}
 
 # make test n=1 t="test/*_wh*.py"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All files must be **syntactically valid Python 3.10+**. Any parse error will hal
 | `--include <mods>`    | Explicitly include additional modules          |
 | `--ignore-clashes`    | Allow duplicate top-level names                |
 
-See [`USAGE.txt`](./doc/0.5/USAGE.txt) for a full CLI specification.
+See [`USAGE.txt`](./doc/0.6/USAGE.txt) for a full CLI specification.
 
 ---
 

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -1,6 +1,6 @@
 # 🛠️ `pyonetrue` Developer Guide
 
-Version: **0.5.3**
+Version: **0.5.4**
 Status: **Stable, Syntax-only Pipeline**
 
 ---

--- a/doc/Re-Implementation-Plan.md
+++ b/doc/Re-Implementation-Plan.md
@@ -1,4 +1,4 @@
-# Implementation Plan for `pyonetrue` v0.5.0
+# Implementation Plan for `pyonetrue` v0.5.4
 
 This plan refocuses **pyonetrue** on its compiler-like mission: _flatten valid Python modules into a unified, executable whole,_ using **`ast.parse()`** for span extraction rather than the CleanEdit library.
 
@@ -57,8 +57,8 @@ This plan refocuses **pyonetrue** on its compiler-like mission: _flatten valid P
 
 ## Phase 4: Version Bump & Documentation
 
-1. **Bump version**  
-   - Set `__version__ = '0.5.0'` in `src/pyonetrue/__init__.py`.
+1. **Bump version**
+   - Set `__version__ = '0.5.4'` in `src/pyonetrue/__init__.py`.
 2. **Update README & CHANGELOG**  
    - Document the shift to AST-based extraction and removal of CleanEdit dependency.
 3. **Migration notes**  
@@ -66,8 +66,8 @@ This plan refocuses **pyonetrue** on its compiler-like mission: _flatten valid P
 
 ## Phase 5: Release & Packaging
 
-1. **Tag release**  
-   - Create Git tag `v0.5.0` in the **pyonetrue** repo.
+1. **Tag release**
+   - Create Git tag `v0.5.4` in the **pyonetrue** repo.
 2. **Publish package**  
    - Build and upload to PyPI or internal index.
 3. **Archive snapshot**  

--- a/doc/User-Guide.md
+++ b/doc/User-Guide.md
@@ -1,6 +1,6 @@
 # 📘 `pyonetrue` User Guide
 
-Version: **0.5.3**
+Version: **0.5.4**
 Status: **Stable, syntax-only**
 
 ---


### PR DESCRIPTION
## Summary
- reference latest `doc/0.6/USAGE.txt` in README and MANIFEST
- bump guide docs to version 0.5.4
- refresh reimplementation plan for 0.5.4
- adjust Makefile comment

## Testing
- `PYTHONPATH=src pytest -q` *(fails: NameError: Span is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684de8855b988326a7471619b5a0856f