### PR TITLE
Sync USAGE docs with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ All files must be **syntactically valid Python 3.10+**. Any parse error will hal
 | Option                | Description                                    |
 | --------------------- | ---------------------------------------------- |
 | `--output <file>`     | Write output to this file (default: stdout)    |
-| `--no-cli`            | Exclude any `__main__.py` module               |
+| `--module-only`       | Build without any `__main__.py` or CLI         |
 | `--main-from <mod>`   | Include only `mod.__main__.py`                 |
+| `--entry <entry>`     | Build specifically for the given entry point   |
 | `--all-guards`        | Include all `if __name__ == '__main__'` blocks |
 | `--guards-from <mod>` | Include only guards from given modules         |
 | `--exclude <mods>`    | Omit these modules (comma-separated)           |
 | `--include <mods>`    | Explicitly include additional modules          |
 | `--ignore-clashes`    | Allow duplicate top-level names                |
 
-See [`USAGE.txt`](./doc/0.6/USAGE.txt) for a full CLI specification.
+See [`USAGE.txt`](./doc/USAGE.txt) for a full CLI specification.
 
 ---
 

--- a/doc/Bundling-Challenges.md
+++ b/doc/Bundling-Challenges.md
@@ -33,7 +33,7 @@
 
 See:
 
-* `--no-cli`, `--main-from`, `--all-guards`, `--guards-from` options
+* `--module-only`, `--main-from`, `--all-guards`, `--guards-from` options
 
 **✔ Result:** Rather than fighting Python’s semantics, `pyonetrue` gives the user **total control** over what is treated as the executable entrypoint. It **never assumes anything magical about module state** — it’s a deliberate design to **be explicit** where Python is implicit.
 

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -90,8 +90,9 @@ Order is always:
 
 | Flag                | Meaning                                |
 | ------------------- | -------------------------------------- |
-| `--no-cli`          | Skip `__main__.py`                     |
+| `--module-only`     | Build without any `__main__.py` or CLI |
 | `--main-from x`     | Include only `x/__main__.py`           |
+| `--entry <entry>`  | Build specifically for the given entry |
 | `--guards-from x,y` | Include main guards from `x`, `y` only |
 | `--all-guards`      | Include all guards                     |
 | `--ignore-clashes`  | Suppress duplicate name check          |

--- a/doc/Re-Implementation-Plan.md
+++ b/doc/Re-Implementation-Plan.md
@@ -34,8 +34,8 @@ This plan refocuses **pyonetrue** on its compiler-like mission: _flatten valid P
 - Ensure flattened modules contain no relative (`.`) imports.
 
 1. **Flag renaming & additions**  
-   - Confirm `--omit-main` is present; remove `--module` if redundant.  
-   - Add `--main-all`, `--main-from <module>`, and `--ignore-clashes` flags.  
+   - Confirm `--module-only` is present; remove `--module` if redundant.
+   - Add `--all-guards`, `--main-from <module>`, and `--ignore-clashes` flags.
 2. **Usage & Documentation**  
    - Revise docstrings in `__main__.py` and `scripts/pyonetrue` to reflect the new AST approach and flags.  
    - Remove any mention of recovery or validation flags like `--trace` if it no longer applies.
@@ -51,7 +51,7 @@ This plan refocuses **pyonetrue** on its compiler-like mission: _flatten valid P
      - Verify imports, classes, functions, and main guards are correctly extracted
      - Ensure `ast.get_source_segment` preserves formatting for simple examples
 3. **CLI tests for flags**  
-   - Under `tests/pyonetrue/`, add tests for `--omit-main`, `--main-all`, `--main-from`, and `--ignore-clashes` behaviors.
+   - Under `tests/pyonetrue/`, add tests for `--module-only`, `--all-guards`, `--main-from`, and `--ignore-clashes` behaviors.
 4. **Regression flattening tests**  
    - Keep existing tests for `classify`, `normalize`, `reorder`, etc., but modify them to use AST spans instead of CodeSpan objects.
 

--- a/doc/USAGE.txt
+++ b/doc/USAGE.txt
@@ -24,45 +24,35 @@ written as:
 <package>/__main__.py is a special module that is executed when the
 package is run as a script.  It is typically used to provide a command-line
 interface to the package.  If such a module is present, it will be included
-at the end of without reordering unless the --no-cli option is used.  Other
+at the end of without reordering unless the --module-only option is used.  Other
 __main__.py modules are not included by default.  If you want to include
 one of them instead, you can use the --main-from option to specify the
 sub-package from which to include __main__.py.
 
 Default behavior is to :
 * All relative imports are eliminated. Flattened output is fully self-contained.
-* Main guards are discarded, but this can be changed with the --main-all
-  or --main-from options.
+* Main guards are discarded, but this can be changed with the --all-guards
+  or --guards-from options.
 * Write the output to stdout, but this can be changed with the --output
 * Name clashes, duplicate top-level names, are not allowed by default.
 * If `__main__.py` is being included, prepend shebang.
 
 Options:
-  -s, --shebang <shebang>  Prepend <sheband> if `__main__.py` is being appended.  [default: "#!/usr/bin/env python3"]
+  -s, --shebang <shebang>  Prepend <shebang> if `__main__.py` is being appended.  [default: #!/usr/bin/env python3]
   -o, --output <file>      Write output to file (default: stdout).
-  --no-cli                 Do not include package's __main__.py.
+  -M, --module-only        Build a pure module without an entry point, i.e. no
+                           __main__ guard, no __main__.py, no CLI.
+  --entry <entry>          Explicitly build for the given entry point.  May be
+                           repeated. If omitted, all entry points are built.
   -m, --main-from <mod>    Include __main__.py from the specified sub-package.
                            Only one __main__.py module is allowed.
-                           Incompatible with --no-cli.
+                           Incompatible with --module-only.
   -a, --all-guards         Include all __main__ guards. (default: discard)
   -g, --guards-from <mod>  Include __main__ guards only from <mod>.
-  -e, --exclude <exclude>  Exclude specified packages or modules, comma separated.
-  -i, --include <include>  Exclude specified packages or modules, comma separated.
+  -E, --exclude <exclude>  Exclude specified packages or modules, comma separated.
+  -i, --include <include>  Include specified packages or modules, comma separated.
   --ignore-clashes         Allow duplicate top-level names without error.
-
-Analysis Options:          Any anlysis option precludes flattening
-  --summary                Summarize over all modules, rather than per-module.
-  --map <json>	           Emit JSON-encoded map: {module: [symbol1, symbol2, ...]}
-  --mains                  List each __main__.py.
-  --imports                List normalized imports.
-  --imports-by-file        List all imports per file.
-  -y, --symbols            List all top-level symbols grouped by type (imports, functions, classes)
-  -t, --structure          Output a structural outline of all modules: imports, defs, guards, main
-  -d, --duplicates         List all duplicated top-level names across modules (like --ignore-clashes dry run)
-  -q, --guards             List all if __name__ == '__main__' blocks by file
-  --empty-files            Report which .py files contain no relevant spans (only comments, docstrings, or whitespace)
-  --counts	               Show a summary count of spans per file: imports, classes, functions, etc.
-
-General Options:
   -h, --help               Show this help message.
   --version                Show version.
+  --show-cli-args          Show the command line arguments that would be passed to the
+                           CLI and exit.  This is useful for debugging.

--- a/doc/User-Guide.md
+++ b/doc/User-Guide.md
@@ -16,7 +16,7 @@ pyonetrue --output foobar.py foobar
 Flatten a package into a single module, without CLI:
 
 ```bash
-pyonetrue --no-cli --output foobar.py foobar
+pyonetrue --module-only --output foobar.py foobar
 ```
 
 Flatten a package directory into a single module:
@@ -65,8 +65,9 @@ Output is written to `stdout` or `--output` path.
 | Option                | Description                                    |
 | --------------------- | ---------------------------------------------- |
 | `--output <file>`     | Write to specified file (default: stdout)      |
-| `--no-cli`            | Exclude package's `__main__.py`                |
+| `--module-only`       | Build without any `__main__.py` or CLI         |
 | `--main-from <mod>`   | Include only this module's `__main__.py`       |
+| `--entry <entry>`     | Build specifically for the given entry point   |
 | `--all-guards`        | Include all `if __name__ == '__main__'` blocks |
 | `--guards-from <mod>` | Include guards only from these modules         |
 | `--exclude <mods>`    | Comma-separated modules/packages to exclude    |
@@ -81,7 +82,7 @@ Output is written to `stdout` or `--output` path.
 | Situation           | Behavior                                        |
 | ------------------- | ----------------------------------------------- |
 | Default             | Primary `__main__.py` is appended               |
-| `--no-cli`          | `__main__.py` is excluded                       |
+| `--module-only`     | `__main__.py` is excluded                       |
 | `--main-from x`     | Only `x/__main__.py` is included                |
 | `--all-guards`      | Includes all `if __name__ == '__main__'` blocks |
 | `--guards-from x,y` | Only from `x`, `y`                              |

--- a/doc/article.md
+++ b/doc/article.md
@@ -83,7 +83,7 @@ You choose your flattening behavior:
 
 * Want the CLI included? Use `--main-from foo.cli`.
 * Want every `__main__` guard? Use `--all-guards`.
-* Want a pure library? Use `--no-cli`.
+* Want a pure library? Use `--module-only`.
 
 The philosophy became clear:
 

--- a/src/pyonetrue/cli.py
+++ b/src/pyonetrue/cli.py
@@ -32,14 +32,14 @@ sub-package from which to include __main__.py.
 
 Default behavior is to :
 * All relative imports are eliminated. Flattened output is fully self-contained.
-* Main guards are discarded, but this can be changed with the --main-all
-  or --main-from options.
+* Main guards are discarded, but this can be changed with the --all-guards
+  or --guards-from options.
 * Write the output to stdout, but this can be changed with the --output
 * Name clashes, duplicate top-level names, are not allowed by default.
 * If `__main__.py` is being included, prepend shebang.
 
 Options:
-  -s, --shebang <shebang>  Prepend <sheband> if `__main__.py` is being appended.  [default: #!/usr/bin/env python3]
+  -s, --shebang <shebang>  Prepend <shebang> if `__main__.py` is being appended.  [default: #!/usr/bin/env python3]
   -o, --output <file>      Write output to file (default: stdout).
   -M, --module-only        Build a pure module without an entry point, i.e. no
                            __main__ guard, no __main__.py, no CLI.
@@ -51,7 +51,7 @@ Options:
   -a, --all-guards         Include all __main__ guards. (default: discard)
   -g, --guards-from <mod>  Include __main__ guards only from <mod>.
   -E, --exclude <exclude>  Exclude specified packages or modules, comma separated.
-  -i, --include <include>  Exclude specified packages or modules, comma separated.
+  -i, --include <include>  Include specified packages or modules, comma separated.
   --ignore-clashes         Allow duplicate top-level names without error.
   -h, --help               Show this help message.
   --version                Show version.


### PR DESCRIPTION
## Summary
- fix typos and flag names in `cli.py` help text
- sync `doc/USAGE.txt` with updated CLI usage
- update docs and README to use `--module-only` and `--all-guards`
- refresh references to `USAGE.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_684e36bd9b1c83268afd5d9d7b645322