### PR TITLE
Document CI ordering root cause

### DIFF
--- a/issue/ci-fails/Root-Cause-Analysis.md
+++ b/issue/ci-fails/Root-Cause-Analysis.md
@@ -1,0 +1,15 @@
+# CI/local ordering mismatch
+
+`pyonetrue` discovers every `.py` file in a package using
+`Path.rglob('*.py')`.  The traversal order of `rglob` depends on the
+underlying operating system and filesystem.  Continuous integration
+and local runs therefore enumerate modules in a different order even
+though the set of files is identical.  Because the flattening process
+emits modules in the discovered order, the generated `pyonetrue.py`
+can be different between CI and a developer's machine while having the
+same byte length.
+
+To guarantee deterministic output, the discovery loop should iterate
+over `sorted(path.rglob('*.py'))` so that modules are always processed
+in lexical order regardless of platform.  This ensures identical
+flattened files both locally and in CI.


### PR DESCRIPTION
## Summary
- add a root cause analysis for nondeterministic module ordering in CI

## Testing
- `PYTHONPATH=src pytest -q` *(fails: NameError: Span not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684ea58ce76883269b291a69caf40e05