### PR TITLE
Add unified recommendation document

### DIFF
--- a/issue/ci-fails/Recomendation.md
+++ b/issue/ci-fails/Recomendation.md
@@ -1,0 +1,11 @@
+# Final Recommendation
+
+The CI failure stemmed from platform-dependent module discovery and symbol ordering. To ensure flattened packages are deterministic and correct, implement the following steps:
+
+1. **Deterministic discovery** – Always iterate over `sorted(path.rglob('*.py'))` when gathering modules so local and CI builds see the same file order.
+2. **Dependency-aware ordering** – Parse each module's imports, build a dependency graph, and topologically sort modules so referenced symbols appear after their definitions.
+3. **Optional user control** – Provide a CLI flag for a custom module order or to preserve per-module grouping without interleaving.
+4. **Post-build validation** – After flattening, run `py_compile` or try importing the result to fail fast if any symbol is used before being defined.
+5. **Improved tests** – Add tests that flatten packages with cross-module references to confirm deterministic output and correct ordering across platforms.
+
+These measures together address nondeterministic discovery and early symbol usage, producing reliable, portable builds.


### PR DESCRIPTION
## Summary
- add a final recommendation document based on earlier proposals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_684eaf572ad083268646c9d03b262d79