### PR TITLE
Fix entry mod selection from entry points

### DIFF
--- a/src/pyonetrue/cli.py
+++ b/src/pyonetrue/cli.py
@@ -237,7 +237,11 @@ def main(argv=sys.argv):
         print(f"CLI args:\n{ctx}")
         return 0
 
-    entry_mods = ctx.entry_points or ([ctx.main_from] if ctx.main_from else [])
+    entry_mods = (
+        [ep.module for ep in ctx.entry_points]
+        if ctx.entry_points
+        else ([ctx.main_from] if ctx.main_from else [])
+    )
     if not entry_mods:
         entry_mods = [None]
 


### PR DESCRIPTION
## Summary
- derive modules from entry point objects rather than `ctx.main_from`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyonetrue')*

------
https://chatgpt.com/codex/tasks/task_b_6850d46df0c08326ab68f4896ae2b905